### PR TITLE
feat: add uploadPostHookTasks in plugin options

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graasp/graasp-plugin-thumbnails#readme",
   "dependencies": {
     "graasp-plugin-file": "github:graasp/graasp-plugin-file",
-    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item#24/hasThumbnail",
+    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item",
     "graasp-plugin-public": "github:graasp/graasp-plugin-public",
     "sharp": "0.29.3"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/graasp/graasp-plugin-thumbnails#readme",
   "dependencies": {
     "graasp-plugin-file": "github:graasp/graasp-plugin-file",
-    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item",
+    "graasp-plugin-file-item": "github:graasp/graasp-plugin-file-item#24/hasThumbnail",
     "graasp-plugin-public": "github:graasp/graasp-plugin-public",
     "sharp": "0.29.3"
   },

--- a/src/publicPlugin.ts
+++ b/src/publicPlugin.ts
@@ -32,6 +32,8 @@ const plugin: FastifyPluginAsync<GraaspPublicThumbnailsOptions> = async (
       items: { taskManager: pTM },
     },
   } = fastify;
+
+  // items' thumbnails
   fastify.register(thumbnailsPlugin, {
     serviceMethod: serviceMethod,
     serviceOptions,
@@ -59,6 +61,7 @@ const plugin: FastifyPluginAsync<GraaspPublicThumbnailsOptions> = async (
     prefix: `${ITEMS_ROUTE}${THUMBNAIL_ROUTE}`,
   });
 
+  // members' avatars
   fastify.register(thumbnailsPlugin, {
     serviceMethod: serviceMethod,
     serviceOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ import {
   UploadPreHookTasksFunction,
   GraaspLocalFileItemOptions,
   GraaspS3FileItemOptions,
+  DownloadPostHookTasksFunction,
+  UploadPostHookTasksFunction,
 } from 'graasp-plugin-file';
 
 declare module 'fastify' {
@@ -24,7 +26,9 @@ export interface GraaspThumbnailsOptions {
   pathPrefix: string;
 
   uploadPreHookTasks?: UploadPreHookTasksFunction;
+  uploadPostHookTasks?: UploadPostHookTasksFunction;
   downloadPreHookTasks: DownloadPreHookTasksFunction;
+  downloadPostHookTasks?: DownloadPostHookTasksFunction;
 
   enableItemsHooks?: boolean;
   enableAppsHooks?: {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -85,6 +85,7 @@ describe('Thumbnail Plugin Tests', () => {
             method: 'GET',
             url: `/${GET_ITEM_ID}/download?size=${size}`,
           });
+
           expect(res.statusCode).toBe(StatusCodes.OK);
           // return value is defined in mock runner
           expect(res.body).toBeTruthy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,14 +3283,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item#24/hasThumbnail":
+"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item":
   version: 0.1.0
-  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=640072ddc76b4bab39814483da3560c44ee67ff9"
+  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=3694c96eea839edc2ca894c77461e916bf341a26"
   dependencies:
     graasp-file-upload-limiter: "github:graasp/graasp-file-upload-limiter"
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
-  checksum: 7b5be0d721b5fb9765edb67f5e12e41a195e2acfe26df05ce53f76cdd9c90650165f3ccb561a77a3490ca59a72884bc5bfa62d8f647482dbc688b8ce6fa330cd
+  checksum: 054ebea4e3de6b0bc7c0a6d740a19fd09386a299677bac3b290179a1dbb1695c1281512f575217fbb117de9afe3e82e38443df0646b0aa6f20ad6bec910f2a44
   languageName: node
   linkType: hard
 
@@ -3334,7 +3334,7 @@ __metadata:
     eslint: ^8.6.0
     fastify: 3.25.3
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
-    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item#24/hasThumbnail"
+    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
     graasp-test: "github:graasp/graasp-test"
     http-status-codes: 2.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,14 +3283,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item":
+"graasp-plugin-file-item@github:graasp/graasp-plugin-file-item#24/hasThumbnail":
   version: 0.1.0
-  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=45600fee4e69507e0188b8ac8cb38cd1e0ee6c58"
+  resolution: "graasp-plugin-file-item@https://github.com/graasp/graasp-plugin-file-item.git#commit=640072ddc76b4bab39814483da3560c44ee67ff9"
   dependencies:
     graasp-file-upload-limiter: "github:graasp/graasp-file-upload-limiter"
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
-  checksum: 7fcb09ac5a48293854996e5958717b8d4cce7156aa18fc3436f65457505d859b24962b44ddceff2c100031eff789c92571a9bc6edfff52ae1a7561e6a0ce1bc9
+  checksum: 7b5be0d721b5fb9765edb67f5e12e41a195e2acfe26df05ce53f76cdd9c90650165f3ccb561a77a3490ca59a72884bc5bfa62d8f647482dbc688b8ce6fa330cd
   languageName: node
   linkType: hard
 
@@ -3334,7 +3334,7 @@ __metadata:
     eslint: ^8.6.0
     fastify: 3.25.3
     graasp-plugin-file: "github:graasp/graasp-plugin-file"
-    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item"
+    graasp-plugin-file-item: "github:graasp/graasp-plugin-file-item#24/hasThumbnail"
     graasp-plugin-public: "github:graasp/graasp-plugin-public"
     graasp-test: "github:graasp/graasp-test"
     http-status-codes: 2.2.0


### PR DESCRIPTION
close #17 

This PR adds the option to add upload post hook. This will be used to update the item with `settings.hasThumbnail = true`
Eventually this plugin could extend settings and its default value.